### PR TITLE
Fix typo bug where object "b" is not being checked

### DIFF
--- a/src/rc-year-calendar.jsx
+++ b/src/rc-year-calendar.jsx
@@ -104,7 +104,7 @@ export default class Calendar extends React.Component {
         }
         else if (a !== null && typeof a === "object" && b !== null && typeof b === "object") {
             var aKeys = Object.keys(a);
-            var bKeys = Object.keys(a);
+            var bKeys = Object.keys(b);
             
             if (aKeys.length !== bKeys.length) {
                 return true;


### PR DESCRIPTION
The typo caused the calendar to not be updated when an event is deleted from the data source